### PR TITLE
Use Math.log10 instead of Math.log

### DIFF
--- a/lib/stuff-classifier/tf-idf.rb
+++ b/lib/stuff-classifier/tf-idf.rb
@@ -7,7 +7,7 @@ class StuffClassifier::TfIdf < StuffClassifier::Base
     total_categories = categories.length
     categories_with_word = (@wcount[word] || []).length
 
-    idf = Math.log((total_categories + 2) / (categories_with_word + 1.0), 10)    
+    idf = Math.log10((total_categories + 2) / (categories_with_word + 1.0))    
     return tf * idf
   end
 


### PR DESCRIPTION
Ruby 1.8 does not support the optional second argument in Math.log. Using Math.log10 works fine.
