### PR TITLE
Reading and writing FileStorage data in binary mode

### DIFF
--- a/lib/stuff-classifier/storage.rb
+++ b/lib/stuff-classifier/storage.rb
@@ -63,7 +63,8 @@ module StuffClassifier
 
     def load_state(classifier)
       if @storage.length == 0 && File.exists?(@path)
-        @storage = Marshal.load(File.read(@path))
+        data = File.open(@path, 'rb') { |f| f.read }
+        @storage = Marshal.load(data)
       end
       storage_to_classifier(classifier)
     end
@@ -79,7 +80,7 @@ module StuffClassifier
     end
 
     def _write_to_file
-      File.open(@path, 'w') do |fh|
+      File.open(@path, 'wb') do |fh|
         fh.flock(File::LOCK_EX)
         fh.write(Marshal.dump(@storage))
       end


### PR DESCRIPTION
Using ruby 1.9.3 on my Mac, I was seeing errors when trying to use FileStorage, e.g.
"\x84" from ASCII-8BIT to UTF-8

I believe the serialized data files should be opened in binary mode.

I don't think any additional test cases are necessary for this.  (Current ones still pass)

Thanks,
Dennis
